### PR TITLE
Rename repository to monad

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# net-utils
+# monad
 
-[![Build workflow](https://img.shields.io/github/workflow/status/K8sbykeshed/net-utils/Go)](https://img.shields.io/github/workflow/status/K8sbykeshed/net-utils/Go)
-[![GoDoc](https://godoc.org/github.com/K8sbykeshed/net-utils?status.svg)](https://godoc.org/github.com/K8sbykeshed/net-utils)
-[![Go Report Card](https://goreportcard.com/badge/github.com/K8sbykeshed/net-utils)](https://goreportcard.com/report/github.com/K8sbykeshed/net-utils)
+[![Build workflow](https://img.shields.io/github/workflow/status/K8sbykeshed/monad/Go)](https://github.com/K8sbykeshed/monad/actions/workflows/go.yml)
+[![GoDoc](https://godoc.org/github.com/K8sbykeshed/monad?status.svg)](https://godoc.org/github.com/K8sbykeshed/monad)
+[![Go Report Card](https://goreportcard.com/badge/github.com/K8sbykeshed/monad)](https://goreportcard.com/report/github.com/K8sbykeshed/monad)
 
 # Networking Utilities
 
@@ -10,4 +10,5 @@ The goal of this Repository is to make it easy for
 us to write an iptables sink module into KPNG, 
 https://github.com/kubernetes-sigs/kpng/ 
 
+The name monad is originated from greek ['μονάς'](https://en.wikipedia.org/wiki/Monad_%28philosophy%29). The network traffic processing is complex, the intention of this project is to bring some simple primitive in this realm, and make the reasoning for networking easier.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/K8sbykeshed/net-utils/pkg/iptables"
 	"log"
+
+	"github.com/K8sbykeshed/monad/pkg/iptables"
 )
 
 func main() {
 	var (
-		err error
+		err  error
 		rule iptables.Rule
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/K8sbykeshed/net-utils
+module github.com/K8sbykeshed/monad
 
 go 1.16

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -2,8 +2,9 @@ package iptables
 
 import (
 	"bytes"
-	"github.com/K8sbykeshed/net-utils/pkg/iptables/utils"
 	"reflect"
+
+	"github.com/K8sbykeshed/monad/pkg/iptables/utils"
 )
 
 // Unmarshal converts a single line from ListRules into a Rule


### PR DESCRIPTION
Rename the repository to monad, which originated from greek 'μονάς'.
We want to break down the complexity of network configuration to monad,
so it could be simple and easy to reason about.

Signed-off-by: Hanlin Shi <shihanlin9@gmail.com>